### PR TITLE
Resize loop

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -3125,11 +3125,10 @@ $.jgrid.extend({
 					$("#jqg_"+$.jgrid.jqID(t.p.id)+"_"+$.jgrid.jqID(sr), "#"+$.jgrid.jqID(t.p.id))[t.p.useProp ? 'prop': 'attr']("checked",false);
 					if(fid) { $("#jqg_"+$.jgrid.jqID(t.p.id)+"_"+$.jgrid.jqID(sr), "#"+$.jgrid.jqID(fid))[t.p.useProp ? 'prop': 'attr']("checked",false); }
 					t.setHeadCheckBox( false);
-
-         var ia = $.inArray($.jgrid.jqID(sr), t.p.selarrrow);
-          if (  ia !== -1 ){
-            t.p.selarrrow.splice(ia,1);
-          }
+					var ia = $.inArray($.jgrid.jqID(sr), t.p.selarrrow);
+					if (  ia !== -1 ){
+						t.p.selarrrow.splice(ia,1);
+					}
 				}
 				sr = null;
 			} else if(!t.p.multiselect) {

--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -2828,8 +2828,12 @@ $.fn.jqGrid = function( pin ) {
 			if($(ptr).length === 0 ){return;}
 			ri = ptr[0].rowIndex;
 			ci = $.jgrid.getCellIndex(td);
-			$(ts).triggerHandler("jqGridDblClickRow", [$(ptr).attr("id"),ri,ci,e]);
-			if ($.isFunction(ts.p.ondblClickRow)) { ts.p.ondblClickRow.call(ts,$(ptr).attr("id"),ri,ci, e); }
+			var dbcr = $(ts).triggerHandler("jqGridDblClickRow", [$(ptr).attr("id"),ri,ci,e]);
+			if( dbcr != null) { return dbcr; }
+			if ($.isFunction(ts.p.ondblClickRow)) { 
+				dbcr = ts.p.ondblClickRow.call(ts,$(ptr).attr("id"),ri,ci, e); 
+				if( dbcr != null) { return dbcr; }
+			}
 		})
 		.bind('contextmenu', function(e) {
 			td = e.target;
@@ -2838,8 +2842,12 @@ $.fn.jqGrid = function( pin ) {
 			if(!ts.p.multiselect) {	$(ts).jqGrid("setSelection",ptr[0].id,true,e);	}
 			ri = ptr[0].rowIndex;
 			ci = $.jgrid.getCellIndex(td);
-			$(ts).triggerHandler("jqGridRightClickRow", [$(ptr).attr("id"),ri,ci,e]);
-			if ($.isFunction(ts.p.onRightClickRow)) { ts.p.onRightClickRow.call(ts,$(ptr).attr("id"),ri,ci, e); }
+			var rcr = $(ts).triggerHandler("jqGridRightClickRow", [$(ptr).attr("id"),ri,ci,e]);
+			if( rcr != null) { return rcr; }
+			if ($.isFunction(ts.p.onRightClickRow)) { 
+				rcr = ts.p.onRightClickRow.call(ts,$(ptr).attr("id"),ri,ci, e); 
+				if( rcr != null) { return rcr; }
+			}
 		});
 		grid.bDiv = document.createElement("div");
 		if(isMSIE) { if(String(ts.p.height).toLowerCase() === "auto") { ts.p.height = "100%"; } }


### PR DESCRIPTION
We had an issue (only in IE 8 AFAIK, its an old one) where resizing the grid from the window resize event caused an infinite loop where resizing the loop then called the window resize event again.

This protects against that.