### PR TITLE
Fix for the slow scrolling bug.

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -992,7 +992,8 @@ $.fn.jqGrid = function( pin ) {
 				}
 				if (npage) {
 					if (p.lastpage && (page > p.lastpage || p.lastpage===1 || (page === p.page && page===p.lastpage)) ) {
-						return;
+						// Fix for the slow scrolling down bug....
+						//return;
 					}
 					if (grid.hDiv.loading) {
 						grid.timer = setTimeout(grid.populateVisible, p.scrollTimeout);


### PR DESCRIPTION
We had a bug where if you scrolled slowly through the grid in infinite scroll mode with server side data that the database wasn't displayed correctly, and we found that this change fixed the problem.

@OlegKi do you have a view on this?