### PR TITLE
Fix bug from "Fix setting of ui-corner-top class"

### DIFF
--- a/js/grid.base.js
+++ b/js/grid.base.js
@@ -3740,7 +3740,7 @@ $.jgrid.extend({
 			this.p.caption=newcap;
 			$("span.ui-jqgrid-title, span.ui-jqgrid-title-rtl",this.grid.cDiv).html(newcap);
 			$(this.grid.cDiv).show();
-			$(grid.cDiv).nextAll("div").removeClass('ui-corner-top');
+			$(this.grid.cDiv).nextAll("div").removeClass('ui-corner-top');
 		});
 	},
 	setLabel : function(colname, nData, prop, attrp ){


### PR DESCRIPTION
The precedent commit  :

https://github.com/openpsa/grid.js/commit/eaee8e668b4d67c33055050c534fcc2682521cd7#diff-2d010088e9cda4a876dbc3e2399c83a0

introduce, when, in case of controlling grid by another grid (for example by an action in onSelectRow), the following bug :

ReferenceError: grid is not defined
$(grid.cDiv).nextAll("div").removeClass('ui-corner-top');

This commit fix it.